### PR TITLE
Add 'facet' paramter call to jquery.swiftype.search.js 

### DIFF
--- a/jquery.swiftype.search.js
+++ b/jquery.swiftype.search.js
@@ -110,6 +110,7 @@
 
           params['search_fields'] = handleFunctionParam(config.searchFields);
           params['fetch_fields'] = handleFunctionParam(config.fetchFields);
+          params['facets'] = handleFunctionParam(config.facets);
           params['filters'] = handleFunctionParam(config.filters);
           params['document_types'] = handleFunctionParam(config.documentTypes);
           params['functional_boosts'] = handleFunctionParam(config.functionalBoosts);
@@ -249,6 +250,7 @@
   $.fn.swiftypeSearch.defaults = {
     attachTo: undefined,
     documentTypes: undefined,
+    facets: undefined,
     filters: undefined,
     engineKey: undefined,
     searchFields: undefined,


### PR DESCRIPTION
in order to match file located in swiftype-faceted-search-example-repo: https://github.com/swiftype/swiftype-faceted-search-example/blob/master/jquery.swiftype.search.js

The same file name in multiple repos caused confusion in working on custom Search results as one file was missing a necessary paramter call using 'facets'.